### PR TITLE
Fix script not working if optional cli-arg "maxprice" not given

### DIFF
--- a/ryanair_api_pull.py
+++ b/ryanair_api_pull.py
@@ -25,7 +25,8 @@ date_limit = date_to.strftime('%Y-%m-%d')
 
 # Other variables for the API call
 airport_code = args['origin']
-price_limit = args['maxprice'] # Price limit for single fare
+price_limit = args['maxprice'] if args['maxprice'] else '' # Price limit for single fare
+
 
 # Define the url for the JSON API
 url = "https://api.ryanair.com/farefinder/3/oneWayFares?&departureAirportIataCode=%s&language=en&limit=30&market=en-gb&offset=0&outboundDepartureDateFrom=%s&outboundDepartureDateTo=%s&priceValueTo=%s" % (airport_code, today_formatted, date_limit, price_limit)


### PR DESCRIPTION
Considering the ‘maxprice’ arg is optional, the script doesn’t work(returns 400 error) when maxprice is not given. This is because the API url ends up having “None” in the last parameter. This is a fix for that, which will assign maxprice with an empty string when arg is not given